### PR TITLE
graue Trennlinie eingebaut unter der Navigationsbar

### DIFF
--- a/src/app/landing-page/landing-page.component.scss
+++ b/src/app/landing-page/landing-page.component.scss
@@ -14,6 +14,7 @@ body {
     height: fit-content;
 }
 
+
 /* Hero Section styles */
 .hero {
     height: 70vh;

--- a/src/app/navigation-bar/navigation-bar.component.scss
+++ b/src/app/navigation-bar/navigation-bar.component.scss
@@ -12,6 +12,8 @@
     font-weight: bold;
     font-size: 25px;
     background-color: white; 
+    border-bottom: 1px solid #ccc;
+    
 }
 
 .navbar-language {


### PR DESCRIPTION
Auf jeder Seite ist nun eine graue Trennlinie, um die Navigationsbar vom Hauptinhalt zu unterscheiden.