### PR TITLE
Hamburger Menü angepasst mit angular material

### DIFF
--- a/src/app/material/material.module.ts
+++ b/src/app/material/material.module.ts
@@ -9,6 +9,7 @@ import {MatIconModule} from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
+import { MatMenuModule } from '@angular/material/menu';
 
 
 @NgModule({
@@ -24,7 +25,8 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
     MatExpansionModule,
     MatProgressBarModule,
     MatDialogModule,
-    MatProgressBarModule
+    MatProgressBarModule, 
+    MatMenuModule
   ],
   exports: [
     MatButtonModule,
@@ -38,7 +40,8 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
     MatExpansionModule,
     MatProgressBarModule,
     MatDialogModule,
-    MatProgressBarModule
+    MatProgressBarModule,
+    MatMenuModule
   ]
 })
 

--- a/src/app/navigation-bar/navigation-bar.component.html
+++ b/src/app/navigation-bar/navigation-bar.component.html
@@ -6,26 +6,33 @@
         </div>
     </a>
 
-    <!-- Checkbox input for the menu button -->
-    <input type="checkbox" id="menu-btn" class="menu-btn" (change)="toggleMenu()" />
-
-    <!-- Label for the checkbox input (Hamburger menu icon) -->
-    <label for="menu-btn" class="navbar-hamburger">
-        <span></span>
-        <span></span>
-        <span></span>
-    </label>
-
-    <!-- Navigation links container -->
-<div class="navbar-menu" [class.show]="isMenuOpen">
+    <!-- Navigation links for larger screens -->
+    <div class="navbar-menu">
         <div class="navItem"><a [routerLink]="['/login']" routerLinkActive="active">{{ login_button }}</a></div>
         <div class="navItem"><a [routerLink]="['/impressum']" routerLinkActive="active">{{ legalNotice_button }}</a></div>
         <div class="navItem"><a [routerLink]="['/contact']" routerLinkActive="active">{{ contact_button }}</a></div> 
         <div class="navItem"><a [routerLink]="['/privacypolicy']" routerLinkActive="active">{{ privacypolicy_button }}</a></div> 
         <div class="navItem"><a [routerLink]="['/faq']" routerLinkActive="active">{{ faq_button }}</a></div>
-
         <div class="navbar-language">
             <img src="assets/900782.png" alt="Sprachauswahl" (click)="openLanguagePopup()">
         </div>
     </div>
+
+    <!-- Icon button for the menu (Hamburger menu icon) -->
+    <button mat-icon-button [matMenuTriggerFor]="menu" class="navbar-hamburger" aria-label="Example icon-button with a menu">
+        <mat-icon>dialpad</mat-icon>
+    </button>
+
+    <!-- Mat menu -->
+    <mat-menu #menu="matMenu">
+        <button mat-menu-item [routerLink]="['/login']" routerLinkActive="active">{{ login_button }}</button>
+        <button mat-menu-item [routerLink]="['/impressum']" routerLinkActive="active">{{ legalNotice_button }}</button>
+        <button mat-menu-item [routerLink]="['/contact']" routerLinkActive="active">{{ contact_button }}</button>
+        <button mat-menu-item [routerLink]="['/privacypolicy']" routerLinkActive="active">{{ privacypolicy_button }}</button>
+        <button mat-menu-item [routerLink]="['/faq']" routerLinkActive="active">{{ faq_button }}</button>
+        <button mat-menu-item (click)="openLanguagePopup()">
+            <img src="assets/900782.png" alt="Sprachauswahl"  class="language-icon">
+        </button>
+    </mat-menu>
+
 </nav>

--- a/src/app/navigation-bar/navigation-bar.component.scss
+++ b/src/app/navigation-bar/navigation-bar.component.scss
@@ -13,13 +13,14 @@
     font-size: 25px;
     background-color: white; 
     border-bottom: 1px solid #ccc;
-    
+    cursor: pointer;
 }
 
 .navbar-language {
     display: flex;
     flex-direction: column; 
     align-items: center; 
+    margin-top: 10px;
 }
 
 .navbar-language img {
@@ -68,6 +69,8 @@ a:visited {
     color: black; 
     padding: 8px 12px;
     border-radius: 4px; 
+    display: inline-block; 
+    overflow: hidden; 
 }
 
 /* Navigation item hover effect */
@@ -77,14 +80,8 @@ a:visited {
     cursor: pointer;
 }
 
-/* Checkbox input for menu button */
-.menu-btn {
-    display: none; 
-}
-
 /* Hamburger menu icon styling */
 .navbar-hamburger {
-
     display: none; 
     flex-direction: column;
     justify-content: center;
@@ -103,55 +100,33 @@ a:visited {
     transition: all 0.2s ease-in-out;
 }
 
-/* Toggle icon appearance when the menu is open */
-.menu-btn:checked ~ .navbar-hamburger span:nth-child(1) {
-    transform: rotate(-45deg) translate(-5px, 5px);
-}
+/* Media query for larger screens */
+@media (min-width: 769px) {
+    .navbar-hamburger {
+        display: none;
+    }
+    .navbar-menu {
+        display: flex;
+    }
+    mat-menu {
+        display: none;
+    }
 
-.menu-btn:checked ~ .navbar-hamburger span:nth-child(2) {
-    opacity: 0;
-}
-
-.menu-btn:checked ~ .navbar-hamburger span:nth-child(3) {
-    transform: rotate(45deg) translate(-8px, -9px);
-}
-
-/* Navigation links container */
-.navbar-menu {
-    display: flex;
-    flex-direction: row; 
-    align-items: center;
-}
-
-.menu-btn:checked ~ .navbar-menu {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    margin-top: 10px;
+    
 }
 
 /* Media query for smaller screens */
 @media (max-width: 768px) {
-  
     .navbar-hamburger {
         display: flex;
     }
-
-  
     .navbar-menu {
         display: none;
     }
-
-  
-    .menu-btn:checked ~ .navbar-menu {
-        background-color: #f2f2f2;
-        display: block;
-        padding-top: 20px;
+     
+    .language-icon{
+        width: 20px; 
+        height: 20px; 
     }
-
-    .navItem {
-        margin-left: 0;
-        margin-bottom: 10px;
-        padding: 0;
-    }
+    
 }

--- a/src/app/navigation-bar/navigation-bar.component.ts
+++ b/src/app/navigation-bar/navigation-bar.component.ts
@@ -4,11 +4,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { LanguageDialogComponent } from './language-dialog/language-dialog.component';
 import { NgIf } from '@angular/common';
 import { NgFor } from '@angular/common';
+import { MaterialModule } from '../material/material.module';
+
 
 @Component({
   selector: 'app-navigation-bar',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive, RouterOutlet, NgIf,NgFor],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet, NgIf,NgFor,MaterialModule],
   templateUrl: './navigation-bar.component.html',
   styleUrl: './navigation-bar.component.scss'
 })


### PR DESCRIPTION
Ich habe das Hamburger Mneü durch mat-icon von Angular Material ersetzt, welches bei kleineren Bilschirmen zu sehen ist und einheitlicher macht, sowie responsiv bleibt.